### PR TITLE
Change Logitech G102/203 symlink to Logitech G Pro's svg

### DIFF
--- a/data/gnome/logitech-g102-g203.svg
+++ b/data/gnome/logitech-g102-g203.svg
@@ -1,1 +1,1 @@
-logitech-g303.svg
+logitech-g-pro.svg


### PR DESCRIPTION
The two mouses have the same design, so I think it's better to symlink the G102's SVG to the G Pro's instead of the G303's.